### PR TITLE
OS変更

### DIFF
--- a/master/Vagrantfile
+++ b/master/Vagrantfile
@@ -6,7 +6,7 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/eoan64"
+  config.vm.box = "ubuntu/bionic64"
   config.ssh.insert_key = false
   config.vm.network "private_network", ip: "192.168.100.10"
   config.vm.provision :shell do |s|


### PR DESCRIPTION
vagrant up を実行したら、not foundとエラーになったので、OSの変更を行った。

```
(⎈ |docker-desktop:default)tshst@tachikoma master % vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'ubuntu/eoan64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
The box 'ubuntu/eoan64' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Vagrant Cloud, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://vagrantcloud.com/ubuntu/eoan64"]
Error: The requested URL returned error: 404 Not Found
```